### PR TITLE
Added support for multi-file torrents. Fixed issues. 

### DIFF
--- a/pieces/cli.py
+++ b/pieces/cli.py
@@ -35,7 +35,7 @@ def main():
 
     args = parser.parse_args()
     if args.verbose:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(filename='logfile.log', level=logging.INFO)
 
     loop = asyncio.get_event_loop()
     client = TorrentClient(Torrent(args.torrent))

--- a/pieces/protocol.py
+++ b/pieces/protocol.py
@@ -316,6 +316,9 @@ class PeerStreamIterator:
             message_length = struct.unpack('>I', self.buffer[0:4])[0]
 
             if message_length == 0:
+                logging.debug('Got a KeepAlive message')
+                # Call consume 
+                self.buffer = self.buffer[header_length + message_length:]
                 return KeepAlive()
 
             if len(self.buffer) >= message_length:

--- a/pieces/tracker.py
+++ b/pieces/tracker.py
@@ -80,6 +80,7 @@ class TrackerResponse:
         # where the peers field is a list of dictionaries and one where all
         # the peers are encoded in a single string
         peers = self.response[b'peers']
+        logging.debug('Type of peers is {0}, and len is {1}'.format(type(peers), len(peers))) 
         if type(peers) == list:
             # TODO Implement support for dictionary peer list
             logging.debug('Dictionary model peers are returned by tracker')
@@ -144,6 +145,8 @@ class Tracker:
             params['event'] = 'started'
 
         url = self.torrent.announce + '?' + urlencode(params)
+        logging.debug(self.torrent.announce_list)
+        logging.debug(self.torrent.announce) 
         logging.info('Connecting to tracker at: ' + url)
 
         async with self.http_client.get(url) as response:
@@ -170,22 +173,6 @@ class Tracker:
         # a successful tracker response will have non-uncicode data, so it's a safe to bet ignore this exception.
         except UnicodeDecodeError:
             pass
-
-    def _construct_tracker_parameters(self):
-        """
-        Constructs the URL parameters used when issuing the announce call
-        to the tracker.
-        """
-        return {
-            'info_hash': self.torrent.info_hash,
-            'peer_id': self.peer_id,
-            'port': 6889,
-            # TODO Update stats when communicating with tracker
-            'uploaded': 0,
-            'downloaded': 0,
-            'left': 0,
-            'compact': 1}
-
 
 def _calculate_peer_id():
     """


### PR DESCRIPTION
Added support for multi-file torrents. 

Fixed bugs:
1. I saw message length is not consumed in the case of keep-alive messages, which leads to an infinite loop when a keep-alive message is received. Fixed that. 
2. Sending out bitfield is not mandatory. Some trackers don't send out bitfields but instead rely on Have messages. Added support for such a tracker. 
3. Storing pending requests is implemented as an immutable object(namedTuple). This raises an error when a re-request is issued. Instead changed it to use a dictionary. 